### PR TITLE
refactor: format scheme-langserver/util/io.sls

### DIFF
--- a/util/io.sls
+++ b/util/io.sls
@@ -1,80 +1,78 @@
 (library (scheme-langserver util io)
-    (export 
-        read-lines 
-        read-line
-        read-to-CRNL
-
-        read-string
-
-        write-lines 
-        write-string)
-    (import (rnrs))
+  (export
+    read-lines
+    read-line
+    read-to-CRNL
+    read-string
+    write-lines
+    write-string)
+  (import (rnrs))
 
 (define (write-lines lines path)
-    (if (not (null? lines))
-        (call-with-output-file path
-            (lambda(port)
-                (let loop ((lines lines))
-                    (write-string (car lines) port)
-                    (if (not (null? (cdr lines)))
-                        (begin 
-                            (write-string "\n" port)
-                            (loop (cdr lines)))))))))
+  (if (not (null? lines))
+    (call-with-output-file path
+      (lambda (port)
+        (let loop ((lines lines))
+          (write-string (car lines) port)
+        (if (not (null? (cdr lines)))
+          (begin
+            (write-string "\n" port)
+            (loop (cdr lines)))))))))
 
 (define (write-string s port)
-    (let loop ((l (string->list s)))
-        (if (null? l)
-            '()
-            (begin 
-                (write-char (car l) port)
-                (loop (cdr l))))))
+  (let loop ((l (string->list s)))
+    (if (null? l)
+      '()
+      (begin
+        (write-char (car l) port)
+        (loop (cdr l))))))
 
 (define (read-to-CRNL port)
-    (let loop ([tail '()] 
-            [current-char (get-u8 port)])
-        (cond 
-            [(eof-object? current-char)
-                (utf8->string (u8-list->bytevector (reverse tail)))]
-            [(and 
-                (= (char->integer #\return ) current-char)
-                (= (char->integer #\newline) (lookahead-u8 port)))
-                (get-u8 port) ;; Consume \n
-                (utf8->string (u8-list->bytevector (reverse tail)))]
-            [(= (char->integer #\newline) current-char)
-                (utf8->string (u8-list->bytevector (reverse tail)))]
-            [else (loop (cons current-char tail) (get-u8 port))])))
+  (let loop ([tail '()]
+    [current-char (get-u8 port)])
+      (cond
+        [(eof-object? current-char)
+          (utf8->string (u8-list->bytevector (reverse tail)))]
+        [(and
+          (= (char->integer #\return ) current-char)
+          (= (char->integer #\newline) (lookahead-u8 port)))
+          (get-u8 port) ;; Consume \n
+          (utf8->string (u8-list->bytevector (reverse tail)))]
+        [(= (char->integer #\newline) current-char)
+          (utf8->string (u8-list->bytevector (reverse tail)))]
+        [else (loop (cons current-char tail) (get-u8 port))])))
 
 (define (read-lines path)
-    (call-with-input-file path
-        (lambda (port)
-            (let loop ((result '()) (item (read-line port)))
-                (if (eof-object? item)
-                result
-                (loop (append result (list item)) (read-line port)))))))
+  (call-with-input-file path
+    (lambda (port)
+      (let loop ((result '()) (item (read-line port)))
+        (if (eof-object? item)
+          result
+          (loop (append result (list item)) (read-line port)))))))
 
 (define (read-line . port)
-    (let ((eat (lambda (p c)
-            (if (and (not (eof-object? (peek-char p))) (char=? (peek-char p) c))
-                (read-char p)))))
-        (let ((p (if (null? port) (current-input-port) (car port))))
-            (let loop ((c (read-char p)) (line '()))
-                (cond 
-                    ((eof-object? c) (if (null? line) c (list->string (reverse line))))
-                    ((char=? #\newline c) (eat p #\return) (list->string (reverse line)))
-                    ((char=? #\return c) (eat p #\newline) (list->string (reverse line)))
-                    (else (loop (read-char p) (cons c line))))))))
+  (let ((eat (lambda (p c)
+          (if (and (not (eof-object? (peek-char p))) (char=? (peek-char p) c))
+            (read-char p)))))
+    (let ((p (if (null? port) (current-input-port) (car port))))
+      (let loop ((c (read-char p)) (line '()))
+        (cond
+          ((eof-object? c) (if (null? line) c (list->string (reverse line))))
+          ((char=? #\newline c) (eat p #\return) (list->string (reverse line)))
+          ((char=? #\return c) (eat p #\newline) (list->string (reverse line)))
+          (else (loop (read-char p) (cons c line))))))))
 
 (define (read-port port)
-    (let loop ((c (read-char port)) (line '()))
-        (cond 
-            ((eof-object? c) (if (null? line) c (list->string (reverse line))))
-            (else (loop (read-char port) (cons c line))))))
+  (let loop ((c (read-char port)) (line '()))
+    (cond
+      ((eof-object? c) (if (null? line) c (list->string (reverse line))))
+      (else (loop (read-char port) (cons c line))))))
 
 (define (read-string path)
-    (call-with-input-file path
-        (lambda (port)
-            (let loop ((c (read-char port)) (line '()))
-                (cond 
-                    ((eof-object? c) (if (null? line) c (list->string (reverse line))))
-                    (else (loop (read-char port) (cons c line))))))))
+  (call-with-input-file path
+    (lambda (port)
+      (let loop ((c (read-char port)) (line '()))
+        (cond
+          ((eof-object? c) (if (null? line) c (list->string (reverse line))))
+          (else (loop (read-char port) (cons c line))))))))
 )


### PR DESCRIPTION
# 自动 format 会遇到的问题

1. 无法自动确定断行位置。对于 `define` 等函数，一般在参数后折行。对于 `and` 和 `cond` 等条件分支，则一般将条件对齐。需要对上下文分析才能做出较为合理的折行方案。
2. 由于 s-exp 嵌套的特性，较难对何时折行做出较为完善的判断。对于较短的一行调用，我们倾向于将其写在一行之中，而对于如 `begin` 开启的多行结构我们倾向于将其按照块结构对齐。自动 format 可能无法应对如此复杂的情况。
3. 断行后不能机械地缩进两空格。对于 lambda 所定义的匿名函数，我们倾向于将参数进行对齐，而不是折行后直接缩进两空格。这也要求自动 format 对代码的结构进行分析。

综上，对 scheme 进行自动 format 极其困难，难以取得让大多数人满意的效果。自动 format 不仅需要工具理解代码的语法结构，还有理解开发者的语义结构和美学倾向，这超出了当前自动化工具的能力。