### PR TITLE
Fix: Handle Completion Edge Cases in `completion.sls`

### DIFF
--- a/protocol/apis/completion.sls
+++ b/protocol/apis/completion.sls
@@ -51,12 +51,14 @@
             (symbol->string (annotation-stripped (index-node-datum/annotations target-index-node)))
             ""))]
       [whole-list
+       (if (null? target-index-node)
+           '()
         (if (equal? "" prefix)
           (find-available-references-for document target-index-node)
           (filter 
             (lambda (candidate-reference) 
               (string-prefix? prefix (symbol->string (identifier-reference-identifier candidate-reference))))
-            (find-available-references-for document target-index-node)))]
+            (find-available-references-for document target-index-node))))]
       [type-inference? (workspace-type-inference? workspace)]
       ; [type-inference? #f]
       )
@@ -145,6 +147,6 @@
       [l (string-length prefix)])
     (make-alist 
       'label s
-      'insertText (substring s (- l 1) (string-length s))
+      'insertText (substring s (if (< l 1) 0 (- l 1)) (string-length s))
       'sortText (string-append index-string-prefix s))))
 )


### PR DESCRIPTION
This PR addresses two specific edge-case scenarios within the `completion.sls` file where invoking VSCode's code completion feature could previously lead to unhandled exceptions. These fixes enhance the stability and reliability of the Scheme language server.

### 1. Completion within Empty Parentheses

**Scenario:**
Invoking VSCode's code completion feature inside a pair of empty parentheses (e.g., `(|)`).

**Problem:**
In this situation, the `identifier-reference->completion-item-alist` function would receive an empty string as the `prefix`. This resulted in the variable `l` being calculated as 0. Consequently, an attempt to use this value in the `substring` function would cause an error due to an invalid (negative) index.

**Solution:**
A conditional logic check has been added for the variable `l` to ensure it does not evaluate to a negative value, thereby preventing the `substring` error.

### 2. Completion in a Blank Space

**Scenario:**
Invoking VSCode's code completion feature in a blank area of the editor (i.e., not within any specific code construct or S-expression).

**Problem:**
When this occurred, the `target-index-node` variable within the `completion` function would be an empty list. This, in turn, would lead to an error in the `find-available-references-for` function when it was called during the assignment of the `whole-list` variable.

**Solution:**
Additional logic has been implemented for the `whole-list` assignment. Now, if `target-index-node` is found to be an empty list, `whole-list` is directly assigned as an empty list. This bypasses the problematic call to `find-available-references-for` in this context and prevents the error.

---

These changes ensure that the completion handler now gracefully manages these scenarios, leading to a more robust and error-free experience for users.

Your review and feedback on these changes would be greatly appreciated!