### PR TITLE
Implement Basic Procedures for Argument Parsing

### DIFF
--- a/run.ss
+++ b/run.ss
@@ -1,20 +1,63 @@
 (import
     (chezscheme)
+    (srfi :37 args-fold)
     (scheme-langserver))
 
-(let ([arg (command-line-arguments)])
-  (if (and (pair? arg) (equal? (car arg) "--help"))
-      (begin
-        (display "Usage:\n")
-        (display "  ./run --help\n")
-        (display "  ./run [input-port] [output-port] [log-path] [enable-multi-thread?] [type-inference?]\n")
-        (display "Arguments:\n")
-        (display "  input-port            Port to read messages (default: stdin)\n")
-        (display "  output-port           Port to write messages (default: stdout)\n")
-        (display "  log-path              Path to write log output (default: null)\n")
-        (display "  enable-multi-thread?  enable | disable (default: disable)\n")
-        (display "  type-inference?       enable | disable (defaule: disable)\n")
-        (display "Example Usage:\n")
-        (display "  ./run /path/to/scheme-langserver.log enable enable\n")
-        (exit 0)))
-  (apply init-server arg))
+(define (display-help)
+  (let ([prog-name (car (command-line))])
+    (display (format "Usage:
+  ~a --help | -h
+  ~a [options] [input-port] [output-port] [log-path]
+
+Options:
+  --multi-thread            enable multi-thread
+  --type-inference          enable type inference
+
+Arguments:
+  input-port                Port to read messages (default: stdin)
+  output-port               Port to write messages (default: stdout)
+  log-path                  Path to write log output (default: null)
+
+Example Usage:
+  ~a /path/to/scheme-langserver.log\n"
+                     prog-name prog-name prog-name))))
+
+(define-record-type scheme-lsp-args
+  (fields
+   (mutable multi-thread)
+   (mutable type-inference)
+   ;; Reversed oprands
+   (mutable oprands)))
+
+(define options
+  (list
+   (option '(#\h "help") #f #f
+           (lambda (opt name arg seeds)
+             (display-help)
+             (exit 0)))
+   (option '("multi-thread") #f #f
+           (lambda (opt name arg seeds)
+             (scheme-lsp-args-multi-thread-set! seeds #t)
+             seeds))
+   (option '("type-inference") #f #f
+           (lambda (opt name arg seeds)
+             (scheme-lsp-args-type-inference-set! seeds #t)
+             seeds))))
+
+(let* ([args (args-fold
+              (command-line-arguments)
+              options
+              (lambda (opt name arg seeds)
+                (format #t "Unrecognized option: ~a\n" name)
+                (display-help)
+                (exit 0))
+              (lambda (operand seeds)
+                (scheme-lsp-args-oprands-set!
+                 seeds
+                 (cons operand
+                       (scheme-lsp-args-oprands seeds)))
+                seeds)
+              (make-scheme-lsp-args #f #f '()))]
+       [operands (reverse (scheme-lsp-args-oprands args))])
+  ;; TODO: use options
+  (apply init-server operands))

--- a/tests/analysis/dependency/rules/test-library-import.sps
+++ b/tests/analysis/dependency/rules/test-library-import.sps
@@ -25,7 +25,7 @@
 (test-begin "library-import-process for ss")
     (let* ([root-file-node (init-virtual-file-system "./run.ss" '() (lambda (fuzzy) #t))]
             [root-index-nodes (document-index-node-list (file-node-document root-file-node))])
-        (test-equal '((chezscheme) (scheme-langserver)) (car (map library-import-process root-index-nodes))))
+        (test-equal '((chezscheme) (srfi :37 args-fold) (scheme-langserver)) (car (map library-import-process root-index-nodes))))
 (test-end)
 
 (exit (if (zero? (test-runner-fail-count (test-runner-get))) 0 1))

--- a/tests/analysis/test-tokenizer.sps
+++ b/tests/analysis/test-tokenizer.sps
@@ -13,7 +13,7 @@
     (scheme-langserver analysis tokenizer))
 
 (test-begin "read ss")
-    (test-equal 2 (length (source-file->annotations "./run.ss")))
+    (test-equal 5 (length (source-file->annotations "./run.ss")))
 (test-end)
 
 (test-begin "read sps")


### PR DESCRIPTION
Implement prototype for #11.

A new record type `scheme-lsp-args` is defined. Currently, only the `oprands` field is used, to keep the command line interface consistent.

Further plan: we may adjust the user experience of the CLI. For example, specify `multi-thread` with options, not oprands.