### PR TITLE
Implement Basic Procedure for Argument Parsing (Refined)

### DIFF
--- a/run.ss
+++ b/run.ss
@@ -1,20 +1,49 @@
 (import
     (chezscheme)
+    (srfi :37 args-fold)
     (scheme-langserver))
 
-(let ([arg (command-line-arguments)])
-  (if (and (pair? arg) (equal? (car arg) "--help"))
-      (begin
-        (display "Usage:\n")
-        (display "  ./run --help\n")
-        (display "  ./run [input-port] [output-port] [log-path] [enable-multi-thread?] [type-inference?]\n")
-        (display "Arguments:\n")
-        (display "  input-port            Port to read messages (default: stdin)\n")
-        (display "  output-port           Port to write messages (default: stdout)\n")
-        (display "  log-path              Path to write log output (default: null)\n")
-        (display "  enable-multi-thread?  enable | disable (default: disable)\n")
-        (display "  type-inference?       enable | disable (defaule: disable)\n")
-        (display "Example Usage:\n")
-        (display "  ./run /path/to/scheme-langserver.log enable enable\n")
-        (exit 0)))
-  (apply init-server arg))
+(define (display-help)
+  (let ([prog-name (car (command-line))])
+    (format (current-error-port) "Usage:
+  ~a --help | -h
+  ~a [input-port] [output-port] [log-path]
+
+Arguments:
+  input-port                Port to read messages (default: stdin)
+  output-port               Port to write messages (default: stdout)
+  log-path                  Path to write log output (default: null)
+
+Example Usage:
+  ~a /path/to/scheme-langserver.log\n"
+            prog-name prog-name prog-name)))
+
+(define options
+  (list
+   (option '(#\h "help") #f #f
+           (lambda (opt name arg seeds)
+             (display-help)
+             (exit 0)))
+   ;; (option '("multi-thread") #f #f
+   ;;         (lambda (opt name arg seeds)
+   ;;           (scheme-lsp-args-multi-thread-set! seeds #t)
+   ;;           seeds))
+   ;; (option '("type-inference") #f #f
+   ;;         (lambda (opt name arg seeds)
+   ;;           (scheme-lsp-args-type-inference-set! seeds #t)
+   ;;           seeds))
+   ))
+
+(let* ([args (args-fold
+              (command-line-arguments)
+              options
+              (lambda (opt name arg seeds)
+                (format (current-error-port) "Unrecognized option: ~a\n" name)
+                (display-help)
+                (exit 0))
+              (lambda (operand seeds)
+                (cons operand seeds))
+              '())]
+       [operands (reverse args)])
+  ;; TODO: use options
+  (apply init-server operands))

--- a/tests/analysis/dependency/rules/test-library-import.sps
+++ b/tests/analysis/dependency/rules/test-library-import.sps
@@ -25,7 +25,7 @@
 (test-begin "library-import-process for ss")
     (let* ([root-file-node (init-virtual-file-system "./run.ss" '() (lambda (fuzzy) #t))]
             [root-index-nodes (document-index-node-list (file-node-document root-file-node))])
-        (test-equal '((chezscheme) (scheme-langserver)) (car (map library-import-process root-index-nodes))))
+        (test-equal '((chezscheme) (srfi :37 args-fold) (scheme-langserver)) (car (map library-import-process root-index-nodes))))
 (test-end)
 
 (exit (if (zero? (test-runner-fail-count (test-runner-get))) 0 1))

--- a/tests/analysis/test-tokenizer.sps
+++ b/tests/analysis/test-tokenizer.sps
@@ -13,7 +13,7 @@
     (scheme-langserver analysis tokenizer))
 
 (test-begin "read ss")
-    (test-equal 2 (length (source-file->annotations "./run.ss")))
+    (test-equal 4 (length (source-file->annotations "./run.ss")))
 (test-end)
 
 (test-begin "read sps")


### PR DESCRIPTION
Refined PR for #12. Avoid breaking changes.

We don't need the record type, as it incurs expensive overheads. Currently we only need a list to store all operands (reversely).