### PR TITLE
feat: Modify GitHub workflow file

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,8 +46,15 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          repo: ufo5260987423/scheme-langserver
+          name: Scheme LangServer Auto-generated Build
+          tag_name: automated_build
           files: |
             build/scheme-langserver-x86_64-linux-glibc
             build/scheme-langserver-x86_64-linux-musl
+          body: |
+            This is an automated release of Scheme LangServer.
+
+            **Commit:** ${{ github.sha }}
+            **Branch:** ${{ github.ref_name }}
+            **Pipeline Run:** ${{ github.run_id }}
 


### PR DESCRIPTION
I have modified the `.github/workflows/release.yaml` file and made the following changes:

- Removed the `repo` variable:
    - This variable specifies which repository the release targets. Since its default value is the current repository, I believe leaving it empty is reasonable.
- Added `name`
- Added `tag_name`
- Added `body` to provide some contextual information.

It is worth noting that in the `softprops/action-gh-release` action, the `overwrite_files` variable defaults to `True`. This means that when we explicitly specify a `tag_name`, the workflow will not repeatedly create new releases but will instead update the files associated with the specified tag. I think this behavior is reasonable for automated builds. However, if you consider this behavior inappropriate, we could modify the `tag_name` to a format like `automated_build-${{ github.run_number }}`. This way, a new release would be created for each commit.

For more configurable options in `softprops/action-gh-release`, you can refer to: [https://github.com/softprops/action-gh-release#inputs](https://github.com/softprops/action-gh-release#inputs)