### PR TITLE
[WIP] feat: Add top-environment parameter to the workspace type

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,8 +46,15 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          repo: ufo5260987423/scheme-langserver
+          name: Scheme LangServer Auto-generated Build
+          tag_name: automated_build
           files: |
             build/scheme-langserver-x86_64-linux-glibc
             build/scheme-langserver-x86_64-linux-musl
+          body: |
+            This is an automated release of Scheme LangServer.
+
+            **Commit:** ${{ github.sha }}
+            **Branch:** ${{ github.ref_name }}
+            **Pipeline Run:** ${{ github.run_id }}
 

--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -52,8 +52,8 @@ RUN akku install
 FROM alpine:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apk update && apk add \
-        git alpine-sdk util-linux-dev libuuid make
+RUN apk update && apk add --no-cache \
+        git alpine-sdk util-linux-dev libuuid make util-linux-static
 
 # add chez scheme
 COPY --from=build-chez /usr/bin/scheme /usr/bin/

--- a/analysis/package-manager/txt-filter.sls
+++ b/analysis/package-manager/txt-filter.sls
@@ -4,14 +4,11 @@
     (chezscheme)
     (scheme-langserver util io)
     (scheme-langserver virtual-file-system file-node)
-    (only (srfi :13 strings) string-suffix? string-prefix? string-contains string-index-right string-index string-take string-drop string-drop-right))
+    (only (srfi :13 strings) string-suffix?))
 
-(define (generate-txt-file-filter list-path)
+(define (generate-txt-file-filter)
   (lambda (path)
-    ;; (pretty-print `(DEBUG: ,path)) 
     (cond
-      [(string-contains path "akku") #f]
       [(string-suffix? ".scm.txt" path) #t]
-      [(file-directory? path) #t]
       [else #f])))
 )

--- a/analysis/workspace.sls
+++ b/analysis/workspace.sls
@@ -63,11 +63,18 @@
     (immutable facet)
     ;only for identifer catching and type inference
     (immutable threaded?)
-    (immutable type-inference?)))
+    (immutable type-inference?)
+    (immutable top-environment)))
 
 (define (refresh-workspace workspace-instance)
   (let* ([path (file-node-path (workspace-file-node workspace-instance))]
-      [root-file-node (init-virtual-file-system path '() (generate-akku-acceptable-file-filter (string-append path "/.akku/list")))]
+      [top-environment (workspace-top-environment workspace-instance)]
+      [filter 
+        (case top-environment
+          ['r6rs (generate-akku-acceptable-file-filter (string-append path "/.akku/list"))]
+          ['r7rs (generate-txt-file-filter)]
+          [else (generate-akku-acceptable-file-filter (string-append path "/.akku/list"))])]
+      [root-file-node (init-virtual-file-system path '() filter)]
       [root-library-node (init-library-node root-file-node)]
       [file-linkage (init-file-linkage root-file-node root-library-node)]
       [batches (get-init-reference-batches file-linkage)])
@@ -95,7 +102,7 @@
           [file-linkage (init-file-linkage root-file-node root-library-node)]
           [batches (get-init-reference-batches file-linkage)])
         (init-references root-file-node root-library-node file-linkage threaded? batches type-inference?)
-        (make-workspace root-file-node root-library-node file-linkage facet threaded? type-inference?))]))
+        (make-workspace root-file-node root-library-node file-linkage facet threaded? type-inference? top-environment))]))
 
 ;; head -[linkage]->files
 ;; for single file

--- a/analysis/workspace.sls
+++ b/analysis/workspace.sls
@@ -85,18 +85,17 @@
     [(path identifier threaded? type-inference?) (init-workspace path identifier 'r6rs threaded? type-inference?)]
     [(path identifier top-environment threaded? type-inference?)
     ;; (pretty-print `(DEBUG: function: init-workspace))
-      (let* ([root-file-node 
-            (init-virtual-file-system path '() 
-              (cond
-                ;todo:add more filter
-                [(equal? 'r7rs top-environment) (generate-txt-file-filter (string-append path "/tests/r7rs"))]
-                [(equal? 'akku identifier) (generate-akku-acceptable-file-filter (string-append path "/.akku/list"))]
-                [else (generate-akku-acceptable-file-filter (string-append path "/.akku/list"))]))]
+      (let* ([facet 
+            (case identifier
+              [txt (generate-txt-file-filter)]
+              [akku (generate-akku-acceptable-file-filter (string-append path "/.akku/list"))]
+              [else (generate-akku-acceptable-file-filter (string-append path "/.akku/list"))])]
+          [root-file-node (init-virtual-file-system path '() facet)]
           [root-library-node (init-library-node root-file-node)]
           [file-linkage (init-file-linkage root-file-node root-library-node)]
           [batches (get-init-reference-batches file-linkage)])
         (init-references root-file-node root-library-node file-linkage threaded? batches type-inference?)
-        (make-workspace root-file-node root-library-node file-linkage identifier threaded? type-inference?))]))
+        (make-workspace root-file-node root-library-node file-linkage facet threaded? type-inference?))]))
 
 ;; head -[linkage]->files
 ;; for single file

--- a/tests/analysis/test-workspace.sps
+++ b/tests/analysis/test-workspace.sps
@@ -76,12 +76,11 @@
 (test-end)
 
 (test-begin "init-workspace-basic-test")
-(let* ([workspace (init-workspace (current-directory) 'akku 'r7rs #f #f)]
-       [root-file-node (workspace-file-node workspace)]
-       [root-library-node (workspace-library-node workspace)])
-  ;; (pretty-print `(DEBUG: workspace ,workspace))
-  (test-equal #f (null? root-file-node))
-  (test-equal #f (null? root-library-node)))
+(let* ([workspace (init-workspace (string-append (current-directory) "/tests/resources/r7rs") 'txt 'r7rs #f #f)]
+        [root-file-node (workspace-file-node workspace)]
+        [root-library-node (workspace-library-node workspace)])
+    (test-equal #f (null? root-file-node))
+    (test-equal #f (null? root-library-node)))
 (test-end)
 
 (exit (if (zero? (test-runner-fail-count (test-runner-get))) 0 1))


### PR DESCRIPTION
- Added (immutable top-environment) to define-record-type workspace
- Modified the refresh-workspace function to determine which filter to use based on top-environment

After introducing this change, a test that uses r7rs as the top-environment started to fail. I am still tracking down this bug, so this PR is not yet complete.