### PR TITLE
try to rewrite the filter in analysis/abstract-interpreter.sls

### DIFF
--- a/analysis/identifier/rules/define-syntax.sls
+++ b/analysis/identifier/rules/define-syntax.sls
@@ -15,7 +15,7 @@
     (scheme-langserver virtual-file-system file-node))
 
 ; reference-identifier-type include 
-; syntax-parameter syntax-variable
+; syntax-parameter syntax-variable syntax parameter
 (define (define-syntax-process root-file-node root-library-node document index-node)
   (let* ([ann (index-node-datum/annotations index-node)]
       [library-identifiers (get-nearest-ancestor-library-identifier index-node)]

--- a/analysis/identifier/rules/library-import.sls
+++ b/analysis/identifier/rules/library-import.sls
@@ -20,6 +20,7 @@
     (scheme-langserver virtual-file-system document)
     (scheme-langserver virtual-file-system file-node))
 
+; reference-identifier-type include 
 ; pointer 
 (define (library-import-process root-file-node root-library-node document index-node)
   (let* ([ann (index-node-datum/annotations index-node)]

--- a/analysis/identifier/rules/r7rs/define-library-import.sls
+++ b/analysis/identifier/rules/r7rs/define-library-import.sls
@@ -15,6 +15,7 @@
     (scheme-langserver virtual-file-system document)
     (scheme-langserver virtual-file-system file-node))
 
+; reference-identifier-type include 
 ; pointer 
 (define (library-import-process-r7rs root-file-node root-library-node document index-node)
   (let* ([ann (index-node-datum/annotations index-node)]

--- a/analysis/identifier/rules/r7rs/define.sls
+++ b/analysis/identifier/rules/r7rs/define.sls
@@ -15,7 +15,7 @@
     (scheme-langserver virtual-file-system file-node))
 
 ; reference-identifier-type include 
-; procedure parameter variable 
+; procedure parameter
 (define (define-r7rs-process root-file-node root-library-node document index-node)
   (let* ([ann (index-node-datum/annotations index-node)]
       [expression (annotation-stripped ann)])

--- a/extract-reference-identifier-type.sh
+++ b/extract-reference-identifier-type.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+TARGET_DIR="analysis/identifier/rules"
+TARGET_COMMENT="; reference-identifier-type include"
+
+find "$TARGET_DIR" -type f -name "*.sls" |\
+xargs grep --no-filename -A 1 "$TARGET_COMMENT" |\
+grep -v "$TARGET_COMMENT" |\
+grep -v -- "^--$" |\
+grep '^;' |\
+sed 's/^;//' |\
+tr ' ' '\n' |\
+grep -v '^$' |\
+sort -u 
+
+# |\ awk '{print "(equal? \x27" $1 " (identifier-reference-type identifier))"}' 


### PR DESCRIPTION
for now, the output of this script is shown below

```
constructor
continuation
getter
let-loop
parameter
pointer
predicator
procedure
setter
syntax
syntax-parameter
syntax-variable
variable
```

I'd like to know how do we rewrite filter function in analysis/abstract-interpreter.sls using this output