### PR TITLE
add define-library in s7 meta-library

### DIFF
--- a/analysis/identifier/meta.sls
+++ b/analysis/identifier/meta.sls
@@ -5501,6 +5501,7 @@ scheme-time scheme-write scheme-r5rs s7))
 ) 'r7rs))
 
 (define s7 (private-process '(s7) '(
+(define-library	syntax)
 (quote syntax)
 (if syntax)
 (when syntax)


### PR DESCRIPTION
I discovered that I had somehow missed the (define-library syntax) in s7, which caused some jumps to not work properly.